### PR TITLE
Rename the deprecated function argument `filters`

### DIFF
--- a/early-dev/app.R
+++ b/early-dev/app.R
@@ -420,7 +420,7 @@ app <- teal::init(
       label = "App Information",
       server = srv_front_page,
       ui = ui_front_page,
-      datanames = "all"
+      datanames = NULL
     ),
     tm_data_table("Data Table"),
     tm_variable_browser("Variable Browser"),

--- a/early-dev/app.R
+++ b/early-dev/app.R
@@ -420,7 +420,7 @@ app <- teal::init(
       label = "App Information",
       server = srv_front_page,
       ui = ui_front_page,
-      filters = "all"
+      datanames = "all"
     ),
     tm_data_table("Data Table"),
     tm_variable_browser("Variable Browser"),


### PR DESCRIPTION
Renames the modules argument `filters` to `datanames` which was deprecated in teal 0.13

This will remove this message from the console
```
The `filters` argument is deprecated and will be removed in the next release. Please use `datanames` instead.
```