### PR TITLE
47 `python` add rounding of values allowing for reproducible code

### DIFF
--- a/python/app.R
+++ b/python/app.R
@@ -38,7 +38,7 @@ numeric_cols = [x for i,x in enumerate(data_columns) if i in numeric_cols_ix]
 svd_res = svd_whiten(data.iloc[:, numeric_cols_ix])
 data_new = pd.concat([data, pd.DataFrame(svd_res)], axis = 1)
 data_new.columns = list(data_columns) + [i + '.whiten' for i in numeric_cols]
-data_new = data_new.round(15)
+data_new = data_new.round(10)
 data_new
 "
 

--- a/python/app.R
+++ b/python/app.R
@@ -38,6 +38,7 @@ numeric_cols = [x for i,x in enumerate(data_columns) if i in numeric_cols_ix]
 svd_res = svd_whiten(data.iloc[:, numeric_cols_ix])
 data_new = pd.concat([data, pd.DataFrame(svd_res)], axis = 1)
 data_new.columns = list(data_columns) + [i + '.whiten' for i in numeric_cols]
+data_new = data_new.round(15)
 data_new
 "
 


### PR DESCRIPTION
### Pull request

- fixes #47 
  - tested on Linux amd64 and docker `ghcr.io/insightsengineering/rstudio_4.3.1_bioc_3.17:latest`
  - none of the python code should depend on a random number generator to justify this discrepancy

### Changes description

- Rounds values at the 10th decimal place _(arbitrary as the problems were mostly detected on the 13-17th)_

### 🔴 Test for reviewer

Preferably the reviewer is not using a Linux machine

- [ ] Confirm the hash of IRIS on your machine is `083f1d3f731bd9fc7e79bafd7bee2fd7` with `rlang::hash(IRIS)`