### PR TITLE
[Feature Request] extend tm_data_table filters in longitudinal app

### DIFF
--- a/longitudinal/app.R
+++ b/longitudinal/app.R
@@ -630,7 +630,7 @@ x <- teal::init(
       datanames = NULL
     ),
     tm_variable_browser(label = "View Variables"),
-    tm_data_table(label = "View Data"),
+    tm_data_table(label = "View Data", dt_args = list(filter = list(position = 'top'))),
     tm_t_summary(
       label = "Demographics",
       dataname = "ADSL",


### PR DESCRIPTION
I understand that show-case apps should have as simples code possible while presenting the most features of our tools. I reckon this small edition to the code bring a lot of functionality to the end user.

This change will bring filters for columns in View Data tab, so that user can filter within multiple columns of the data when viewing the data. First print screen shows missing filters, where the second one shows the proposition of the functionality that we will provide.

![image](https://github.com/insightsengineering/teal.gallery/assets/133694481/7760a4ee-628a-4dec-aafc-d3e2a23cd1f4)
![image](https://github.com/insightsengineering/teal.gallery/assets/133694481/8ae2008b-b005-43e8-b9aa-eba49f1c617f)
