### PR TITLE
Trigger deployment only when pushed on main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,6 +3,8 @@ name: Deploy Apps 🚀
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: "12 3 * * *"


### PR DESCRIPTION
We only want the deployments to occur in these three scenarios:
1. Code is merged to `main`
2. Workflow dispatch when we need to test deployments manually
3. Automatically trigger it every day at 3:12 AM