### PR TITLE
Use the correct checkout branch name for stable channel

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           echo "BRANCH_NAME=dev" >> $GITHUB_ENV
           if [ "${{ matrix.channel }}" == "stable" ]; then
-            echo "BRANCH_NAME=stable" >> $GITHUB_ENV
+            echo "BRANCH_NAME=main" >> $GITHUB_ENV
           fi
 
       - name: Setup job token 🔑


### PR DESCRIPTION
There seems to be a typo when BRANCH_NAME is set.