### PR TITLE
Install tmc from CRAN

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           echo "BRANCH_NAME=dev" >> $GITHUB_ENV
           if [ "${{ matrix.channel }}" == "stable" ]; then
-            echo "BRANCH_NAME=main" >> $GITHUB_ENV
+            echo "BRANCH_NAME=tmc-from-cran@main" >> $GITHUB_ENV
           fi
 
       - name: Setup job token 🔑

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
           lockfile <- renv::lockfile_read()
           pkg_name_structure <- ifelse("${{ matrix.channel }}" == "stable", "%s/%s@*release", "%s/%s")
           unreleased_packages <- c(
-            "osprey", "hermes", "goshawk", "teal.modules.general", "teal.modules.clinical",
+            "osprey", "hermes", "goshawk", "teal.modules.general",
             "teal.osprey", "teal.modules.hermes", "teal.goshawk", "nestcolor"
           )
           for (package in lockfile$Packages) {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           echo "BRANCH_NAME=dev" >> $GITHUB_ENV
           if [ "${{ matrix.channel }}" == "stable" ]; then
-            echo "BRANCH_NAME=tmc-from-cran@main" >> $GITHUB_ENV
+            echo "BRANCH_NAME=main" >> $GITHUB_ENV
           fi
 
       - name: Setup job token 🔑

--- a/early-dev/renv.lock
+++ b/early-dev/renv.lock
@@ -2669,13 +2669,8 @@
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",
       "Version": "0.9.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.clinical",
-      "RemoteRef": "v0.9.0",
-      "RemoteSha": "c2db189c2761805929b7d3ccfca9e244fe2280ec",
+      "Source": "Repository",
+      "Repository": "CRAN",
       "Requirements": [
         "DT",
         "R",
@@ -2711,7 +2706,7 @@
         "utils",
         "vistime"
       ],
-      "Hash": "9782a8d51126761c8737584f2bbcd4d7"
+      "Hash": "8a228ec3700320f55de3b44fd751cef4"
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",

--- a/efficacy/renv.lock
+++ b/efficacy/renv.lock
@@ -2506,14 +2506,14 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9023",
+      "Version": "0.2.16.9026",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
+      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
       "Requirements": [
         "DT",
         "R",
@@ -2545,7 +2545,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "fa8c6e7546118959e63640f8dece07c0"
+      "Hash": "71ea7e7b231126585310ab30781a488a"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/efficacy/renv.lock
+++ b/efficacy/renv.lock
@@ -2465,13 +2465,8 @@
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",
       "Version": "0.9.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.clinical",
-      "RemoteRef": "v0.9.0",
-      "RemoteSha": "c2db189c2761805929b7d3ccfca9e244fe2280ec",
+      "Source": "Repository",
+      "Repository": "CRAN",
       "Requirements": [
         "DT",
         "R",
@@ -2507,18 +2502,18 @@
         "utils",
         "vistime"
       ],
-      "Hash": "9782a8d51126761c8737584f2bbcd4d7"
+      "Hash": "8a228ec3700320f55de3b44fd751cef4"
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9026",
+      "Version": "0.2.16.9023",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
+      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
       "Requirements": [
         "DT",
         "R",
@@ -2550,7 +2545,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "71ea7e7b231126585310ab30781a488a"
+      "Hash": "fa8c6e7546118959e63640f8dece07c0"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/longitudinal/renv.lock
+++ b/longitudinal/renv.lock
@@ -2798,14 +2798,14 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9023",
+      "Version": "0.2.16.9026",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
+      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
       "Requirements": [
         "DT",
         "R",
@@ -2837,7 +2837,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "fa8c6e7546118959e63640f8dece07c0"
+      "Hash": "71ea7e7b231126585310ab30781a488a"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/longitudinal/renv.lock
+++ b/longitudinal/renv.lock
@@ -2757,13 +2757,8 @@
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",
       "Version": "0.9.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.clinical",
-      "RemoteRef": "v0.9.0",
-      "RemoteSha": "c2db189c2761805929b7d3ccfca9e244fe2280ec",
+      "Source": "Repository",
+      "Repository": "CRAN",
       "Requirements": [
         "DT",
         "R",
@@ -2799,18 +2794,18 @@
         "utils",
         "vistime"
       ],
-      "Hash": "9782a8d51126761c8737584f2bbcd4d7"
+      "Hash": "8a228ec3700320f55de3b44fd751cef4"
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9026",
+      "Version": "0.2.16.9023",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
+      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
       "Requirements": [
         "DT",
         "R",
@@ -2842,7 +2837,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "71ea7e7b231126585310ab30781a488a"
+      "Hash": "fa8c6e7546118959e63640f8dece07c0"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/patient-profile/renv.lock
+++ b/patient-profile/renv.lock
@@ -2500,14 +2500,14 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9023",
+      "Version": "0.2.16.9026",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
+      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
       "Requirements": [
         "DT",
         "R",
@@ -2539,7 +2539,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "fa8c6e7546118959e63640f8dece07c0"
+      "Hash": "71ea7e7b231126585310ab30781a488a"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/patient-profile/renv.lock
+++ b/patient-profile/renv.lock
@@ -2459,13 +2459,8 @@
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",
       "Version": "0.9.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.clinical",
-      "RemoteRef": "v0.9.0",
-      "RemoteSha": "c2db189c2761805929b7d3ccfca9e244fe2280ec",
+      "Source": "Repository",
+      "Repository": "CRAN",
       "Requirements": [
         "DT",
         "R",
@@ -2501,18 +2496,18 @@
         "utils",
         "vistime"
       ],
-      "Hash": "9782a8d51126761c8737584f2bbcd4d7"
+      "Hash": "8a228ec3700320f55de3b44fd751cef4"
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9026",
+      "Version": "0.2.16.9023",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
+      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
       "Requirements": [
         "DT",
         "R",
@@ -2544,7 +2539,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "71ea7e7b231126585310ab30781a488a"
+      "Hash": "fa8c6e7546118959e63640f8dece07c0"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/safety/renv.lock
+++ b/safety/renv.lock
@@ -2511,14 +2511,14 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9023",
+      "Version": "0.2.16.9026",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
+      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
       "Requirements": [
         "DT",
         "R",
@@ -2550,7 +2550,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "fa8c6e7546118959e63640f8dece07c0"
+      "Hash": "71ea7e7b231126585310ab30781a488a"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/safety/renv.lock
+++ b/safety/renv.lock
@@ -2470,13 +2470,8 @@
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",
       "Version": "0.9.0",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.clinical",
-      "RemoteRef": "v0.9.0",
-      "RemoteSha": "c2db189c2761805929b7d3ccfca9e244fe2280ec",
+      "Source": "Repository",
+      "Repository": "CRAN",
       "Requirements": [
         "DT",
         "R",
@@ -2512,18 +2507,18 @@
         "utils",
         "vistime"
       ],
-      "Hash": "9782a8d51126761c8737584f2bbcd4d7"
+      "Hash": "8a228ec3700320f55de3b44fd751cef4"
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.2.16.9026",
+      "Version": "0.2.16.9023",
       "Source": "GitHub",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
       "RemoteUsername": "insightsengineering",
       "RemoteRepo": "teal.modules.general",
       "RemoteRef": "main",
-      "RemoteSha": "c9f87bf8b8ecc4b3176481c2ef252a676c998b33",
+      "RemoteSha": "09ccfc191f50343d3cbcf3a3705699ff65900772",
       "Requirements": [
         "DT",
         "R",
@@ -2555,7 +2550,7 @@
         "tidyselect",
         "utils"
       ],
-      "Hash": "71ea7e7b231126585310ab30781a488a"
+      "Hash": "fa8c6e7546118959e63640f8dece07c0"
     },
     "teal.reporter": {
       "Package": "teal.reporter",


### PR DESCRIPTION
As tmc is released on CRAN we should replace the stable `renv.lock` files to use tmc from CRAN instead of GitHub.