### PR TITLE
Install released version of tmg in the stable deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,8 +132,8 @@ jobs:
           lockfile <- renv::lockfile_read()
           pkg_name_structure <- ifelse("${{ matrix.channel }}" == "stable", "%s/%s@*release", "%s/%s")
           unreleased_packages <- c(
-            "osprey", "hermes", "goshawk", "teal.modules.general",
-            "teal.osprey", "teal.modules.hermes", "teal.goshawk", "nestcolor"
+            "osprey", "hermes", "goshawk", "teal.osprey",
+            "teal.modules.hermes", "teal.goshawk", "nestcolor"
           )
           for (package in lockfile$Packages) {
               if (package$Source == "GitHub") {

--- a/RNA-seq/renv.lock
+++ b/RNA-seq/renv.lock
@@ -3028,14 +3028,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -3067,7 +3062,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.modules.hermes": {
       "Package": "teal.modules.hermes",

--- a/early-dev/renv.lock
+++ b/early-dev/renv.lock
@@ -2700,14 +2700,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2739,7 +2734,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.osprey": {
       "Package": "teal.osprey",

--- a/efficacy/renv.lock
+++ b/efficacy/renv.lock
@@ -2496,14 +2496,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2535,7 +2530,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/exploratory/renv.lock
+++ b/exploratory/renv.lock
@@ -2256,14 +2256,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2295,7 +2290,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/longitudinal/renv.lock
+++ b/longitudinal/renv.lock
@@ -2788,14 +2788,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2827,7 +2822,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/patient-profile/renv.lock
+++ b/patient-profile/renv.lock
@@ -2490,14 +2490,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2529,7 +2524,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/python/renv.lock
+++ b/python/renv.lock
@@ -2266,14 +2266,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2305,7 +2300,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.reporter": {
       "Package": "teal.reporter",

--- a/safety/renv.lock
+++ b/safety/renv.lock
@@ -2501,14 +2501,9 @@
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",
-      "Version": "0.3.0.9003",
-      "Source": "GitHub",
-      "RemoteType": "github",
-      "RemoteHost": "api.github.com",
-      "RemoteUsername": "insightsengineering",
-      "RemoteRepo": "teal.modules.general",
-      "RemoteRef": "main",
-      "RemoteSha": "1fc1653508d1d7096070954313389e061eec81c8",
+      "Version": "0.3.0",
+      "Source": "Repository",
+      "Repository": "RSPM",
       "Requirements": [
         "DT",
         "R",
@@ -2540,7 +2535,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "2e13f73c7aa77beacb4995cff76bf0f6"
+      "Hash": "f54d7bc27cd048cec3a842f980c74e9b"
     },
     "teal.reporter": {
       "Package": "teal.reporter",


### PR DESCRIPTION
As tmg is released we want to use the CRAN version of tmg for stable deployments.