### PR TITLE
Use github version of teal.logger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,7 +132,7 @@ jobs:
           lockfile <- renv::lockfile_read()
           pkg_name_structure <- ifelse("${{ matrix.channel }}" == "stable", "%s/%s@*release", "%s/%s")
           unreleased_packages <- c(
-            "osprey", "hermes", "goshawk", "teal.osprey",
+            "osprey", "hermes", "goshawk", "teal.osprey", "teal.logger",
             "teal.modules.hermes", "teal.goshawk", "nestcolor"
           )
           for (package in lockfile$Packages) {

--- a/RNA-seq/renv.lock
+++ b/RNA-seq/renv.lock
@@ -3013,18 +3013,25 @@
     },
     "teal.logger": {
       "Package": "teal.logger",
-      "Version": "0.1.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
+      "Version": "0.1.3.9013",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "teal.logger",
+      "RemoteUsername": "insightsengineering",
+      "RemotePkgRef": "insightsengineering/teal.logger",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "723a974d47b7aa7af309d37fb1c09963da797be5",
       "Requirements": [
         "R",
         "glue",
         "lifecycle",
         "logger",
+        "methods",
         "shiny",
         "withr"
       ],
-      "Hash": "7fcc2929a04dc755d0683f93716f534b"
+      "Hash": "a3ee0edd6a3648b4b57b46a550e16024"
     },
     "teal.modules.general": {
       "Package": "teal.modules.general",

--- a/early-dev/renv.lock
+++ b/early-dev/renv.lock
@@ -2643,18 +2643,25 @@
     },
     "teal.logger": {
       "Package": "teal.logger",
-      "Version": "0.1.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
+      "Version": "0.1.3.9013",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "teal.logger",
+      "RemoteUsername": "insightsengineering",
+      "RemotePkgRef": "insightsengineering/teal.logger",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "723a974d47b7aa7af309d37fb1c09963da797be5",
       "Requirements": [
         "R",
         "glue",
         "lifecycle",
         "logger",
+        "methods",
         "shiny",
         "withr"
       ],
-      "Hash": "7fcc2929a04dc755d0683f93716f534b"
+      "Hash": "a3ee0edd6a3648b4b57b46a550e16024"
     },
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",

--- a/longitudinal/renv.lock
+++ b/longitudinal/renv.lock
@@ -2731,18 +2731,25 @@
     },
     "teal.logger": {
       "Package": "teal.logger",
-      "Version": "0.1.3",
-      "Source": "Repository",
-      "Repository": "RSPM",
+      "Version": "0.1.3.9013",
+      "Source": "GitHub",
+      "RemoteType": "github",
+      "RemoteHost": "api.github.com",
+      "RemoteRepo": "teal.logger",
+      "RemoteUsername": "insightsengineering",
+      "RemotePkgRef": "insightsengineering/teal.logger",
+      "RemoteRef": "HEAD",
+      "RemoteSha": "723a974d47b7aa7af309d37fb1c09963da797be5",
       "Requirements": [
         "R",
         "glue",
         "lifecycle",
         "logger",
+        "methods",
         "shiny",
         "withr"
       ],
-      "Hash": "7fcc2929a04dc755d0683f93716f534b"
+      "Hash": "a3ee0edd6a3648b4b57b46a550e16024"
     },
     "teal.modules.clinical": {
       "Package": "teal.modules.clinical",


### PR DESCRIPTION
As some of the module packages are installed from GitHub we need the latest GitHub version of `teal.logger` for [three apps that fail stable deployments](https://github.com/insightsengineering/teal.gallery/actions/runs/8372437831/job/22923398662).