### PR TITLE
Showcase different `teal_slices` in Basic teal app + update header and footer

### DIFF
--- a/RNA-seq/app.R
+++ b/RNA-seq/app.R
@@ -17,7 +17,7 @@ datanames(data) <- c("ADTTE", "MAE")
 
 ## App header and footer ----
 nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/python"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/RNA-seq"
 gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
 
 header <- tags$span(
@@ -39,7 +39,7 @@ footer <- tags$p(
 
 app <- init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("RNA-Seq Analysis Teal Demo App", nest_logo),
   header = header,
   footer = footer,
   modules = modules(

--- a/RNA-seq/app.R
+++ b/RNA-seq/app.R
@@ -2,8 +2,6 @@ library(teal.modules.hermes)
 library(teal.modules.general)
 options(shiny.useragg = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -17,9 +15,33 @@ data <- within(data, {
 })
 datanames(data) <- c("ADTTE", "MAE")
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/python"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
 
 app <- init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   modules = modules(
     tm_front_page(
       label = "App Info",
@@ -62,55 +84,7 @@ app <- init(
       adtte_name = "ADTTE",
       mae_name = "MAE"
     )
-  ),
-  title = build_app_title("RNA-Seq Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app focusing on analysis of RNA-seq data with teal.modules.hermes"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/RNA-seq",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
 )
 
 ## Not run:

--- a/basic-teal/app.R
+++ b/basic-teal/app.R
@@ -1,67 +1,70 @@
 library(teal)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 data <- teal_data()
 data <- within(data, {
-  IRIS <- iris
+  library(dplyr)
+
+  IRIS <- iris %>%
+    mutate(
+      Species1 = Species,
+      Species2 = Species,
+      Species3 = Species,
+      Species4 = Species,
+      Species5 = Species
+    )
   MTCARS <- mtcars
 })
 
-app <- init(
-  data = data,
-  filter = teal_slices(
-    teal_slice(dataname = "IRIS", varname = "Species", multiple = FALSE)
+filters <- teal_slices(
+  teal_slice(dataname = "MTCARS", varname = "gear", multiple = FALSE),
+  teal_slice(dataname = "IRIS", varname = "Species"),
+  teal_slice(dataname = "IRIS", varname = "Sepal.Length"),
+  teal_slice(
+    dataname = "IRIS", varname = "Species3",
+    fixed = TRUE, anchored = FALSE
   ),
-  modules = modules(example_module()),
-  title = build_app_title("Basic Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "My first teal app"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
+  teal_slice(
+    dataname = "IRIS", varname = "Species4",
+    fixed = FALSE, anchored = TRUE, multiple = TRUE
   ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/basic-teal",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
+  teal_slice(
+    dataname = "IRIS", varname = "Species5",
+    fixed = TRUE, anchored = TRUE
+  ),
+  teal_slice(
+    dataname = "IRIS", id = "custom_expr", title = "Custom Expression",
+    expr = "Sepal.Width > 2.5 & Petal.Length > 1.5",
   )
 )
 
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/basic-teal"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
+app <- init(
+  data = data,
+  filter = filters,
+  modules = modules(example_module()),
+  title = build_app_title("Basic Teal Demo App", nest_logo),
+  header = header,
+  footer = footer
 )
 
 shinyApp(app$ui, app$server)

--- a/early-dev/app.R
+++ b/early-dev/app.R
@@ -3,8 +3,6 @@ library(teal.modules.general)
 library(teal.osprey)
 options(shiny.useragg = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -216,9 +214,34 @@ cs_paramcd_tr <- choices_selected(
   selected = "SLDINV"
 )
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/early-dev"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 ## Setup App
 app <- init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   filter = teal_slices(
     count_type = "all",
     teal_slice(dataname = "ADSL", varname = "SAFFL", selected = "Y"),
@@ -420,58 +443,8 @@ app <- init(
       x_limit = "-28, 750",
       plot_height = c(1200, 400, 5000)
     )
-  ),
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app focusing on analysis of early-phase clinical trial data with teal.osprey"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/early-dev",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
 )
-
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
-)
-
 
 ## Start Teal Shiny App ----
 shinyApp(app$ui, app$server)

--- a/efficacy/app.R
+++ b/efficacy/app.R
@@ -2,8 +2,6 @@ library(teal.modules.general)
 library(teal.modules.clinical)
 options(shiny.useragg = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -132,9 +130,34 @@ arm_ref_comp <- list(
   ARM = list(ref = "A: Drug X", comp = c("B: Placebo", "C: Combination"))
 )
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/efficacy"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 ## Setup App
 app <- init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   filter = teal_slices(
     count_type = "all",
     teal_slice(dataname = "ADSL", varname = "ITTFL", selected = "Y"),
@@ -279,55 +302,7 @@ app <- init(
       cov_var = choices_selected(variable_choices(ADQS, c("BASE", "STRATA1", "SEX")), "STRATA1"),
       paramcd = cs_paramcd_qs
     )
-  ),
-  title = build_app_title("Efficacy Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app focusing on efficacy analysis of clinical trial data with teal.modules.clinical"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/efficacy",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
 )
 
 shinyApp(app$ui, app$server)

--- a/efficacy/app.R
+++ b/efficacy/app.R
@@ -155,7 +155,7 @@ footer <- tags$p(
 ## Setup App
 app <- init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("Efficacy Analysis Teal Demo App", nest_logo),
   header = header,
   footer = footer,
   filter = teal_slices(

--- a/exploratory/app.R
+++ b/exploratory/app.R
@@ -227,7 +227,7 @@ footer <- tags$p(
 
 app <- init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("Exploratory Analysis Teal Demo App", nest_logo),
   header = header,
   footer = footer,
   filter = teal_slices(

--- a/exploratory/app.R
+++ b/exploratory/app.R
@@ -4,8 +4,6 @@ options(
   teal.ggplot2_args = teal.widgets::ggplot2_args(labs = list(caption = "NEST PROJECT"))
 )
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -205,8 +203,33 @@ distr_filter_spec <- filter_spec(
   multiple = TRUE
 )
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/exploratory"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 app <- init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   filter = teal_slices(
     count_type = "all",
     teal_slice(dataname = "ADSL", varname = "SEX"),
@@ -327,55 +350,7 @@ app <- init(
       plot_height = c(600L, 200L, 2000L),
       plot_width = c(600L, 200L, 2000L)
     )
-  ),
-  title = build_app_title("Exploratory Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app for general dataset exploration with teal.modules.general"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/exploratory",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
 )
 
 shinyApp(app$ui, app$server)

--- a/longitudinal/app.R
+++ b/longitudinal/app.R
@@ -4,8 +4,6 @@ library(teal.modules.clinical)
 library(teal.modules.general)
 options(shiny.useragg = FALSE, shiny.sanitize.errors = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -414,8 +412,33 @@ paramexcldDict <- paramDict %>%
 paramexcld_list <- paramexcldDict$PARAM
 paramcdexcld_list <- paramexcldDict$PARAMCD
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/longitudinal"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 app <- teal::init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   filter = teal_slices(
     count_type = "all",
     teal_slice(dataname = "ADSL", varname = "SEX"),
@@ -798,28 +821,6 @@ body(app$server)[[length(body(app$server)) + 1]] <- quote(
       p("PCHG =  % Change from Baseline"),
       p("AVAL = Visit Values"),
       p("AVALL2 = Log2(AVAL)"),
-      easyClose = TRUE
-    ))
-  })
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
       easyClose = TRUE
     ))
   })

--- a/longitudinal/app.R
+++ b/longitudinal/app.R
@@ -436,7 +436,7 @@ footer <- tags$p(
 
 app <- teal::init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("Longitudinal Analysis Teal Demo App", nest_logo),
   header = header,
   footer = footer,
   filter = teal_slices(
@@ -771,32 +771,6 @@ app <- teal::init(
         hline_vars = c("ANRHI", "ANRLO", "ULOQN", "LLOQN"),
         hline_vars_colors = c("pink", "brown", "purple", "gray")
       )
-    )
-  ),
-  title = build_app_title("Longitudinal Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app focusing on analysis of longitudinal clinical trial data with teal.goshawk"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/longitudinal",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
     )
   )
 )

--- a/patient-profile/app.R
+++ b/patient-profile/app.R
@@ -102,7 +102,7 @@ footer <- tags$p(
 
 app <- init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("Patient Profile Analysis Teal Demo App", nest_logo),
   header = header,
   footer = footer,
   filter = teal_slices(

--- a/patient-profile/app.R
+++ b/patient-profile/app.R
@@ -2,8 +2,6 @@ library(teal.modules.clinical)
 library(teal.modules.general)
 options(shiny.useragg = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -80,8 +78,33 @@ cmdecod_input <- choices_selected(
   selected = "CMDECOD"
 )
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/patient-profile"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 app <- init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   filter = teal_slices(
     count_type = "all",
     teal_slice(dataname = "ADSL", varname = "SEX"),
@@ -288,55 +311,7 @@ app <- init(
         selected = "AENDY"
       ),
     )
-  ),
-  title = build_app_title("Patient Profile Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app focusing on patient-level analysis of clinical trial data with teal.modules.clinical"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/patient-profile",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
 )
 
 shinyApp(app$ui, app$server)

--- a/python/app.R
+++ b/python/app.R
@@ -10,8 +10,6 @@ library(sparkline)
 
 options(shiny.useragg = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 data <- teal_data_module(
   ui = function(id) {
     ns <- NS(id)
@@ -84,8 +82,33 @@ data_new
   }
 )
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/python"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 app <- teal::init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   title = build_app_title("Python Dataset Teal Demo App", nest_logo),
   modules = modules(
     tm_data_table("Data Table"),
@@ -133,54 +156,7 @@ app <- teal::init(
         )
       )
     )
-  ),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app using python dataset connector"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/python",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
 )
 
 shinyApp(app$ui, app$server)

--- a/python/app.R
+++ b/python/app.R
@@ -106,10 +106,9 @@ footer <- tags$p(
 
 app <- teal::init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("Python Dataset Teal Demo App", nest_logo),
   header = header,
   footer = footer,
-  title = build_app_title("Python Dataset Teal Demo App", nest_logo),
   modules = modules(
     tm_data_table("Data Table"),
     tm_variable_browser("Variable Browser"),

--- a/safety/app.R
+++ b/safety/app.R
@@ -2,8 +2,6 @@ library(teal.modules.general)
 library(teal.modules.clinical)
 options(shiny.useragg = FALSE)
 
-nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
-
 ## Data reproducible code ----
 data <- teal_data()
 data <- within(data, {
@@ -159,9 +157,34 @@ aesi_vars <-
   names(ADAE)[startsWith(names(ADAE), "TMP_SMQ") |
     startsWith(names(ADAE), "TMP_CQ")]
 
+## App header and footer ----
+nest_logo <- "https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/PNG/nest.png"
+app_source <- "https://github.com/insightsengineering/teal.gallery/tree/main/safety"
+gh_issues_page <- "https://github.com/insightsengineering/teal.gallery/issues"
+
+header <- tags$span(
+  style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
+  tags$span("My first teal app", style = "font-size: 30px;"),
+  tags$span(
+    style = "display: flex; align-items: center;",
+    tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
+    tags$span(style = "font-size: 24px;", "NEST @ Roche")
+  )
+)
+
+footer <- tags$p(
+  "This teal app is brought to you by the NEST Team at Roche/Genentech.
+        For more information, please visit:",
+  tags$a(href = app_source, target = "_blank", "Source Code"), ", ",
+  tags$a(href = gh_issues_page, target = "_blank", "Report Issues")
+)
+
 ## Setup App
 app <- teal::init(
   data = data,
+  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  header = header,
+  footer = footer,
   # Set initial filter state as safety-evaluable population
   filter = teal_slices(
     count_type = "all",
@@ -475,55 +498,7 @@ app <- teal::init(
       param = choices_selected(value_choices(ADLB, "PARAMCD", "PARAM"), "ALT"),
       plot_height = c(1000L, 200L, 4000L)
     )
-  ),
-  title = build_app_title("Safety Analysis Teal Demo App", nest_logo),
-  header = tags$span(
-    style = "display: flex; align-items: center; justify-content: space-between; margin: 10px 0 10px 0;",
-    tags$span(
-      style = "font-size: 30px;",
-      "Example teal app focusing on safety analysis of clinical trial data with teal.modules.clinical"
-    ),
-    tags$span(
-      style = "display: flex; align-items: center;",
-      tags$img(src = nest_logo, alt = "NEST logo", height = "45px", style = "margin-right:10px;"),
-      tags$span(style = "font-size: 24px;", "NEST @ Roche")
-    )
-  ),
-  footer = tags$p(
-    actionLink("showAboutModal", "About,"),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/tree/main/safety",
-      target = "_blank",
-      "Source Code,"
-    ),
-    tags$a(
-      href = "https://github.com/insightsengineering/teal.gallery/issues",
-      target = "_blank",
-      "Report Issues"
-    )
   )
-)
-
-body(app$server)[[length(body(app$server)) + 1]] <- quote(
-  observeEvent(input$showAboutModal, {
-    showModal(modalDialog(
-      tags$p(
-        "This teal app is brought to you by the NEST Team at Roche/Genentech.
-        For more information, please visit:"
-      ),
-      tags$ul(
-        tags$li(tags$a(
-          href = "https://github.com/insightsengineering", "Insights Engineering",
-          target = "blank"
-        )),
-        tags$li(tags$a(
-          href = "https://pharmaverse.org", "Pharmaverse",
-          target = "blank"
-        ))
-      ),
-      easyClose = TRUE
-    ))
-  })
 )
 
 shinyApp(app$ui, app$server)

--- a/safety/app.R
+++ b/safety/app.R
@@ -182,7 +182,7 @@ footer <- tags$p(
 ## Setup App
 app <- teal::init(
   data = data,
-  title = build_app_title("Early Development Analysis Teal Demo App", nest_logo),
+  title = build_app_title("Safety Analysis Teal Demo App", nest_logo),
   header = header,
   footer = footer,
   # Set initial filter state as safety-evaluable population


### PR DESCRIPTION
Closes #70 

Changes:
1. Basic teal app is updated to showcase all possible filter variations.
2. Simplified the apps by removing the custom server logic for observe popup and moved it to the footer.