### PR TITLE
Upgrade BioC packages for RNA-seq

### DIFF
--- a/RNA-seq/renv.lock
+++ b/RNA-seq/renv.lock
@@ -58,8 +58,9 @@
   "Packages": {
     "AnnotationDbi": {
       "Package": "AnnotationDbi",
-      "Version": "1.64.1",
+      "Version": "1.66.0",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "Biobase",
         "BiocGenerics",
@@ -73,7 +74,7 @@
         "stats",
         "stats4"
       ],
-      "Hash": "27587689922e22f60ec9ad0182a0a825"
+      "Hash": "b7df9c597fb5533fc8248d73b8c703ac"
     },
     "BH": {
       "Package": "BH",
@@ -86,28 +87,19 @@
       "Package": "Biobase",
       "Version": "2.62.0",
       "Source": "Bioconductor",
-      "Requirements": [
-        "BiocGenerics",
-        "R",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["BiocGenerics", "R", "methods", "utils"],
       "Hash": "38252a34e82d3ff6bb46b4e2252d2dce"
     },
     "BiocBaseUtils": {
       "Package": "BiocBaseUtils",
       "Version": "1.4.0",
       "Source": "Bioconductor",
-      "Requirements": [
-        "R",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["R", "methods", "utils"],
       "Hash": "8fdda3c850b2bea92ad4d0877c9549d1"
     },
     "BiocFileCache": {
       "Package": "BiocFileCache",
-      "Version": "2.10.2",
+      "Version": "2.12.0",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -123,19 +115,13 @@
         "stats",
         "utils"
       ],
-      "Hash": "d59a927de08cce606299009cc595b2cb"
+      "Hash": "9c3414bcfae204d56080dd0f0a220136"
     },
     "BiocGenerics": {
       "Package": "BiocGenerics",
       "Version": "0.48.1",
       "Source": "Bioconductor",
-      "Requirements": [
-        "R",
-        "graphics",
-        "methods",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "graphics", "methods", "stats", "utils"],
       "Hash": "e34278c65d7dffcc08f737bf0944ca9a"
     },
     "BiocManager": {
@@ -143,9 +129,7 @@
       "Version": "1.30.25",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
+      "Requirements": ["utils"],
       "Hash": "3aec5928ca10897d7a0a1205aae64627"
     },
     "BiocParallel": {
@@ -170,14 +154,12 @@
       "Package": "BiocVersion",
       "Version": "3.18.1",
       "Source": "Bioconductor",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "2ecaed86684f5fae76ed5530f9d29c4a"
     },
     "Biostrings": {
       "Package": "Biostrings",
-      "Version": "2.70.3",
+      "Version": "2.72.1",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -189,12 +171,11 @@
         "XVector",
         "crayon",
         "grDevices",
-        "graphics",
         "methods",
         "stats",
         "utils"
       ],
-      "Hash": "86ffa781f132f54e9c963a13fd6cf9fc"
+      "Hash": "886ff0ed958d6f839ed2e0d01f6853b3"
     },
     "ComplexHeatmap": {
       "Package": "ComplexHeatmap",
@@ -228,15 +209,12 @@
       "Version": "1.2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods"
-      ],
+      "Requirements": ["R", "methods"],
       "Hash": "065ae649b05f1ff66bb0c793107508f5"
     },
     "DESeq2": {
       "Package": "DESeq2",
-      "Version": "1.42.1",
+      "Version": "1.44.0",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -256,7 +234,7 @@
         "methods",
         "stats4"
       ],
-      "Hash": "39ce3d1e4fe223602fd27d2ae92c8535"
+      "Hash": "a90e0e67215ba95ccb29e93b169caaa4"
     },
     "DT": {
       "Package": "DT",
@@ -299,9 +277,7 @@
       "Version": "4.1.6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "methods"
-      ],
+      "Requirements": ["methods"],
       "Hash": "cd52c065c9e687c60c56b51f10f7bcd3"
     },
     "EnvStats": {
@@ -309,12 +285,7 @@
       "Version": "3.0.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "MASS",
-        "R",
-        "ggplot2",
-        "nortest"
-      ],
+      "Requirements": ["MASS", "R", "ggplot2", "nortest"],
       "Hash": "08f0337e9a3b03a9027a423a1ae76ed3"
     },
     "Formula": {
@@ -322,15 +293,12 @@
       "Version": "1.2-5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats"
-      ],
+      "Requirements": ["R", "stats"],
       "Hash": "7a29697b75e027767a53fde6c903eca7"
     },
     "GenomeInfoDb": {
       "Package": "GenomeInfoDb",
-      "Version": "1.38.8",
+      "Version": "1.40.1",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -338,28 +306,27 @@
         "GenomeInfoDbData",
         "IRanges",
         "R",
-        "RCurl",
         "S4Vectors",
+        "UCSC.utils",
         "methods",
         "stats",
         "stats4",
         "utils"
       ],
-      "Hash": "155053909d2831bfac154a1118151d6b"
+      "Hash": "171e9becd9bb948b9e64eb3759208c94"
     },
     "GenomeInfoDbData": {
       "Package": "GenomeInfoDbData",
-      "Version": "1.2.11",
+      "Version": "1.2.12",
       "Source": "Bioconductor",
-      "Requirements": [
-        "R"
-      ],
-      "Hash": "10f32956181d1d46bd8402c93ac193e8"
+      "Requirements": ["R"],
+      "Hash": "c3c792a7b7f2677be56e8632c5b7543d"
     },
     "GenomicRanges": {
       "Package": "GenomicRanges",
-      "Version": "1.54.1",
+      "Version": "1.56.2",
       "Source": "Bioconductor",
+      "Repository": "Bioconductor 3.19",
       "Requirements": [
         "BiocGenerics",
         "GenomeInfoDb",
@@ -372,20 +339,14 @@
         "stats4",
         "utils"
       ],
-      "Hash": "7e0c1399af35369312d9c399454374e8"
+      "Hash": "fecd026026c4d45e3b57eee97bbbba92"
     },
     "GetoptLong": {
       "Package": "GetoptLong",
       "Version": "1.0.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "GlobalOptions",
-        "R",
-        "crayon",
-        "methods",
-        "rjson"
-      ],
+      "Requirements": ["GlobalOptions", "R", "crayon", "methods", "rjson"],
       "Hash": "61fac01c73abf03ac72e88dc3952c1e3"
     },
     "GlobalOptions": {
@@ -393,11 +354,7 @@
       "Version": "0.1.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["R", "methods", "utils"],
       "Hash": "c3f7b221e60c28f5f3533d74c6fef024"
     },
     "IRanges": {
@@ -419,13 +376,7 @@
       "Package": "KEGGREST",
       "Version": "1.42.0",
       "Source": "Bioconductor",
-      "Requirements": [
-        "Biostrings",
-        "R",
-        "httr",
-        "methods",
-        "png"
-      ],
+      "Requirements": ["Biostrings", "R", "httr", "methods", "png"],
       "Hash": "8d6e9f4dce69aec9c588c27ae79be08e"
     },
     "MASS": {
@@ -464,10 +415,7 @@
       "Package": "MatrixGenerics",
       "Version": "1.14.0",
       "Source": "Bioconductor",
-      "Requirements": [
-        "matrixStats",
-        "methods"
-      ],
+      "Requirements": ["matrixStats", "methods"],
       "Hash": "088cd2077b5619fcb7b373b1a45174e7"
     },
     "MatrixModels": {
@@ -475,12 +423,7 @@
       "Version": "0.5-3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "Matrix",
-        "R",
-        "methods",
-        "stats"
-      ],
+      "Requirements": ["Matrix", "R", "methods", "stats"],
       "Hash": "0776bf7526869e0286b0463cb72fb211"
     },
     "MultiAssayExperiment": {
@@ -524,10 +467,7 @@
       "Version": "1.8.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "278c286fd6e9e75d0c2e8f731ea445c8"
     },
     "R.oo": {
@@ -535,12 +475,7 @@
       "Version": "1.27.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R.methodsS3",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["R", "R.methodsS3", "methods", "utils"],
       "Hash": "6ac79ff194202248cf946fe3a5d6d498"
     },
     "R.utils": {
@@ -548,14 +483,7 @@
       "Version": "2.12.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R.methodsS3",
-        "R.oo",
-        "methods",
-        "tools",
-        "utils"
-      ],
+      "Requirements": ["R", "R.methodsS3", "R.oo", "methods", "tools", "utils"],
       "Hash": "3dc2829b790254bfba21e60965787651"
     },
     "R6": {
@@ -563,9 +491,7 @@
       "Version": "2.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "470851b6d5d0ac559e9d01bb352b4021"
     },
     "RColorBrewer": {
@@ -573,9 +499,7 @@
       "Version": "1.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "45f0398006e83a5b10b72a90663d8d8c"
     },
     "RCurl": {
@@ -583,11 +507,7 @@
       "Version": "1.98-1.16",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "bitops",
-        "methods"
-      ],
+      "Requirements": ["R", "bitops", "methods"],
       "Hash": "ddbdf53d15b47be4407ede6914f56fbb"
     },
     "RSQLite": {
@@ -614,10 +534,7 @@
       "Version": "1.0.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["methods", "utils"],
       "Hash": "e7bdd9ee90e96921ca8a0f1972d66682"
     },
     "RcppArmadillo": {
@@ -625,13 +542,7 @@
       "Version": "14.2.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp",
-        "methods",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "Rcpp", "methods", "stats", "utils"],
       "Hash": "9da7c242d94a8419d045f6b3a64b9765"
     },
     "RcppEigen": {
@@ -639,12 +550,7 @@
       "Version": "0.3.4.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "Rcpp", "stats", "utils"],
       "Hash": "4ac8e423216b8b70cb9653d1b3f71eb9"
     },
     "Rdpack": {
@@ -652,18 +558,12 @@
       "Version": "2.6.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods",
-        "rbibutils",
-        "tools",
-        "utils"
-      ],
+      "Requirements": ["R", "methods", "rbibutils", "tools", "utils"],
       "Hash": "a9e2118c664c2cd694f03de074e8d4b3"
     },
     "S4Arrays": {
       "Package": "S4Arrays",
-      "Version": "1.2.1",
+      "Version": "1.4.1",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -677,7 +577,7 @@
         "methods",
         "stats"
       ],
-      "Hash": "3213a9826adb8f48e51af1e7b30fa568"
+      "Hash": "deeed4802c5132e88f24a432a1caf5e0"
     },
     "S4Vectors": {
       "Package": "S4Vectors",
@@ -696,7 +596,7 @@
     },
     "SparseArray": {
       "Package": "SparseArray",
-      "Version": "1.2.4",
+      "Version": "1.4.8",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -710,22 +610,17 @@
         "XVector",
         "matrixStats",
         "methods",
-        "stats"
+        "stats",
+        "utils"
       ],
-      "Hash": "391092e7b81373ab624bd6471cebccd4"
+      "Hash": "97f70ff11c14edd379ee2429228cbb60"
     },
     "SparseM": {
       "Package": "SparseM",
       "Version": "1.84-2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "methods",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "graphics", "methods", "stats", "utils"],
       "Hash": "e78499cbcbbca98200254bd171379165"
     },
     "SummarizedExperiment": {
@@ -756,11 +651,7 @@
       "Version": "3.99-0.18",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["R", "methods", "utils"],
       "Hash": "4a5eca1070ecfe97e68727ed4b9a89fa"
     },
     "XVector": {
@@ -784,11 +675,7 @@
       "Version": "1.4-8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["R", "methods", "utils"],
       "Hash": "2288423bb0f20a457800d7fc47f6aa54"
     },
     "askpass": {
@@ -796,9 +683,7 @@
       "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "sys"
-      ],
+      "Requirements": ["sys"],
       "Hash": "c39f4155b3ceb1a9a2799d700fbd4b6a"
     },
     "assertthat": {
@@ -806,9 +691,7 @@
       "Version": "0.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "tools"
-      ],
+      "Requirements": ["tools"],
       "Hash": "50c838a310445e954bc13f26f26a6ecf"
     },
     "backports": {
@@ -816,9 +699,7 @@
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "e1e1b9d75c37401117b636b7ae50827a"
     },
     "base64enc": {
@@ -826,22 +707,19 @@
       "Version": "0.1-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "543776ae6848fde2f48ff3816d0628bc"
     },
     "biomaRt": {
       "Package": "biomaRt",
-      "Version": "2.58.2",
+      "Version": "2.60.1",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
         "AnnotationDbi",
         "BiocFileCache",
-        "XML",
         "digest",
-        "httr",
+        "httr2",
         "methods",
         "progress",
         "rappdirs",
@@ -849,16 +727,14 @@
         "utils",
         "xml2"
       ],
-      "Hash": "d6e043a6bfb4e2e256d00b8eee9c4266"
+      "Hash": "e53d495b9e6ecd5394acad1d53c3fa22"
     },
     "bit": {
       "Package": "bit",
       "Version": "4.5.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "f89f074e0e49bf1dbe3eba0a15a91476"
     },
     "bit64": {
@@ -866,14 +742,7 @@
       "Version": "4.6.0-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "bit",
-        "graphics",
-        "methods",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "bit", "graphics", "methods", "stats", "utils"],
       "Hash": "4f572fbc586294afff277db583b9060f"
     },
     "bitops": {
@@ -888,11 +757,7 @@
       "Version": "1.2.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "methods",
-        "rlang",
-        "vctrs"
-      ],
+      "Requirements": ["methods", "rlang", "vctrs"],
       "Hash": "40415719b5a479b87949f3aa0aee737c"
     },
     "boot": {
@@ -900,11 +765,7 @@
       "Version": "1.3-31",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "stats"
-      ],
+      "Requirements": ["R", "graphics", "stats"],
       "Hash": "de2a4646c18661d6a0a08ec67f40b7ed"
     },
     "broom": {
@@ -954,10 +815,7 @@
       "Version": "1.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "fastmap",
-        "rlang"
-      ],
+      "Requirements": ["fastmap", "rlang"],
       "Hash": "cd9a672193789068eb5a2aad65a0dedf"
     },
     "car": {
@@ -990,9 +848,7 @@
       "Version": "3.0-5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "ac6cdb8552c61bd36b0e54d07cf2aab7"
     },
     "checkmate": {
@@ -1000,11 +856,7 @@
       "Version": "2.3.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "backports",
-        "utils"
-      ],
+      "Requirements": ["R", "backports", "utils"],
       "Hash": "0e14e01ce07e7c88fd25de6d4260d26b"
     },
     "circlize": {
@@ -1031,10 +883,7 @@
       "Version": "3.6.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "b21916dd77a27642b447374a5d30ecf3"
     },
     "clue": {
@@ -1042,13 +891,7 @@
       "Version": "0.3-66",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cluster",
-        "graphics",
-        "methods",
-        "stats"
-      ],
+      "Requirements": ["R", "cluster", "graphics", "methods", "stats"],
       "Hash": "3604501a29faffcd155ae84c1872eaf3"
     },
     "cluster": {
@@ -1056,13 +899,7 @@
       "Version": "2.1.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "grDevices", "graphics", "stats", "utils"],
       "Hash": "b361779da7f8b129a1859b6cf243ba58"
     },
     "codetools": {
@@ -1070,9 +907,7 @@
       "Version": "0.2-20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "61e097f35917d342622f21cdc79c256e"
     },
     "colorspace": {
@@ -1080,13 +915,7 @@
       "Version": "2.1-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "methods",
-        "stats"
-      ],
+      "Requirements": ["R", "grDevices", "graphics", "methods", "stats"],
       "Hash": "d954cb1c57e8d8b756165d7ba18aa55a"
     },
     "commonmark": {
@@ -1118,9 +947,7 @@
       "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "9df43854f1c84685d095ed6270b52387"
     },
     "crayon": {
@@ -1128,11 +955,7 @@
       "Version": "1.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "grDevices",
-        "methods",
-        "utils"
-      ],
+      "Requirements": ["grDevices", "methods", "utils"],
       "Hash": "859d96e65ef198fd43e82b9628d593ef"
     },
     "crosstalk": {
@@ -1140,12 +963,7 @@
       "Version": "1.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R6",
-        "htmltools",
-        "jsonlite",
-        "lazyeval"
-      ],
+      "Requirements": ["R6", "htmltools", "jsonlite", "lazyeval"],
       "Hash": "ab12c7b080a57475248a30f4db6298c0"
     },
     "curl": {
@@ -1153,9 +971,7 @@
       "Version": "6.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "8dd23d308c751efdf675124aad4bf5d7"
     },
     "data.table": {
@@ -1163,10 +979,7 @@
       "Version": "1.16.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods"
-      ],
+      "Requirements": ["R", "methods"],
       "Hash": "38bbf05fc2503143db4c734a7e5cab66"
     },
     "dbplyr": {
@@ -1202,10 +1015,7 @@
       "Version": "0.6.37",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "33698c4b3127fc9f506654607fb73676"
     },
     "doBy": {
@@ -1237,13 +1047,7 @@
       "Version": "1.0.17",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "foreach",
-        "iterators",
-        "parallel",
-        "utils"
-      ],
+      "Requirements": ["R", "foreach", "iterators", "parallel", "utils"],
       "Hash": "451e5edf411987991ab6a5410c45011f"
     },
     "dplyr": {
@@ -1271,7 +1075,7 @@
     },
     "edgeR": {
       "Package": "edgeR",
-      "Version": "4.0.16",
+      "Version": "4.2.2",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
       "Requirements": [
@@ -1284,7 +1088,7 @@
         "stats",
         "utils"
       ],
-      "Hash": "a0405c7890708dcb53809d46758800f4"
+      "Hash": "4c31c0395110252e4ec7cf4ee9cbebb6"
     },
     "emmeans": {
       "Package": "emmeans",
@@ -1308,10 +1112,7 @@
       "Version": "1.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats"
-      ],
+      "Requirements": ["R", "stats"],
       "Hash": "21ec52af13afbcab1cb317567b639b0a"
     },
     "evaluate": {
@@ -1319,9 +1120,7 @@
       "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "e9651417729bbe7472e32b5027370e79"
     },
     "fansi": {
@@ -1329,11 +1128,7 @@
       "Version": "1.0.6",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "utils"
-      ],
+      "Requirements": ["R", "grDevices", "utils"],
       "Hash": "962174cf2aeb5b9eea581522286a911f"
     },
     "farver": {
@@ -1355,9 +1150,7 @@
       "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "192053c276525c8495ccfd523aa8f2d1"
     },
     "flextable": {
@@ -1389,9 +1182,7 @@
       "Version": "0.1.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "f6068021eff4aba735a9b2353516636c"
     },
     "fontLiberation": {
@@ -1399,9 +1190,7 @@
       "Version": "0.1.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "f918c5e723f86f409912104d5b7a71d6"
     },
     "fontawesome": {
@@ -1409,11 +1198,7 @@
       "Version": "0.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "htmltools",
-        "rlang"
-      ],
+      "Requirements": ["R", "htmltools", "rlang"],
       "Hash": "bd1297f9b5b1fc1372d19e2c4cd82215"
     },
     "fontquiver": {
@@ -1421,11 +1206,7 @@
       "Version": "0.2.1",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "fontBitstreamVera",
-        "fontLiberation"
-      ],
+      "Requirements": ["R", "fontBitstreamVera", "fontLiberation"],
       "Hash": "fc0f4226379e451057d55419fd31761e"
     },
     "forcats": {
@@ -1449,12 +1230,7 @@
       "Version": "1.5.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "codetools",
-        "iterators",
-        "utils"
-      ],
+      "Requirements": ["R", "codetools", "iterators", "utils"],
       "Hash": "618609b42c9406731ead03adf5379850"
     },
     "formatR": {
@@ -1462,9 +1238,7 @@
       "Version": "1.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "63cb26d12517c7863f5abb006c5e0f25"
     },
     "formatters": {
@@ -1488,10 +1262,7 @@
       "Version": "1.6.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods"
-      ],
+      "Requirements": ["R", "methods"],
       "Hash": "7f48af39fa27711ea5fbd183b399920d"
     },
     "futile.logger": {
@@ -1499,12 +1270,7 @@
       "Version": "1.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "futile.options",
-        "lambda.r",
-        "utils"
-      ],
+      "Requirements": ["R", "futile.options", "lambda.r", "utils"],
       "Hash": "99f0ace8c05ec7d3683d27083c4f1e7e"
     },
     "futile.options": {
@@ -1512,9 +1278,7 @@
       "Version": "1.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "0d9bf02413ddc2bbe8da9ce369dcdd2b"
     },
     "gdtools": {
@@ -1537,10 +1301,7 @@
       "Version": "0.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods"
-      ],
+      "Requirements": ["R", "methods"],
       "Hash": "15e9634c0fcd294799e9b2e929ed1b86"
     },
     "ggfortify": {
@@ -1626,10 +1387,7 @@
       "Version": "1.8.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "methods"
-      ],
+      "Requirements": ["R", "methods"],
       "Hash": "5899f1eaa825580172bb56c08266f37c"
     },
     "gridExtra": {
@@ -1637,13 +1395,7 @@
       "Version": "2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "grDevices",
-        "graphics",
-        "grid",
-        "gtable",
-        "utils"
-      ],
+      "Requirements": ["grDevices", "graphics", "grid", "gtable", "utils"],
       "Hash": "7d7f283939f563670a697165b2cf5560"
     },
     "gtable": {
@@ -1714,10 +1466,7 @@
       "Version": "0.11",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "xfun"
-      ],
+      "Requirements": ["R", "xfun"],
       "Hash": "d65ba49117ca223614f71b60d85b8ab7"
     },
     "hms": {
@@ -1725,13 +1474,7 @@
       "Version": "1.1.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "lifecycle",
-        "methods",
-        "pkgconfig",
-        "rlang",
-        "vctrs"
-      ],
+      "Requirements": ["lifecycle", "methods", "pkgconfig", "rlang", "vctrs"],
       "Hash": "b59377caa7ed00fa41808342002138f9"
     },
     "htmltools": {
@@ -1770,14 +1513,7 @@
       "Version": "1.6.15",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "Rcpp",
-        "later",
-        "promises",
-        "utils"
-      ],
+      "Requirements": ["R", "R6", "Rcpp", "later", "promises", "utils"],
       "Hash": "d55aa087c47a63ead0f6fc10f8fa1ee0"
     },
     "httr": {
@@ -1785,14 +1521,7 @@
       "Version": "1.4.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "R6",
-        "curl",
-        "jsonlite",
-        "mime",
-        "openssl"
-      ],
+      "Requirements": ["R", "R6", "curl", "jsonlite", "mime", "openssl"],
       "Hash": "ac107251d9d9fd72f0ca8049988f1d7f"
     },
     "isoband": {
@@ -1800,10 +1529,7 @@
       "Version": "0.2.7",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "grid",
-        "utils"
-      ],
+      "Requirements": ["grid", "utils"],
       "Hash": "0080607b4a1a7b28979aecef976d8bc2"
     },
     "iterators": {
@@ -1811,10 +1537,7 @@
       "Version": "1.0.14",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "8954069286b4b2b0d023d1b288dce978"
     },
     "jquerylib": {
@@ -1822,9 +1545,7 @@
       "Version": "0.1.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "htmltools"
-      ],
+      "Requirements": ["htmltools"],
       "Hash": "5aab57a3bd297eee1c1d862735972182"
     },
     "jsonlite": {
@@ -1832,9 +1553,7 @@
       "Version": "1.8.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "methods"
-      ],
+      "Requirements": ["methods"],
       "Hash": "4e993b65c2c3ffbffce7bb3e2c6f832b"
     },
     "knitr": {
@@ -1858,10 +1577,7 @@
       "Version": "0.4.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "graphics",
-        "stats"
-      ],
+      "Requirements": ["graphics", "stats"],
       "Hash": "b64ec208ac5bc1852b285f665d6368b3"
     },
     "lambda.r": {
@@ -1869,10 +1585,7 @@
       "Version": "1.2.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "formatR"
-      ],
+      "Requirements": ["R", "formatR"],
       "Hash": "b1e925c4b9ffeb901bacf812cbe9a6ad"
     },
     "later": {
@@ -1880,10 +1593,7 @@
       "Version": "1.4.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "Rcpp",
-        "rlang"
-      ],
+      "Requirements": ["Rcpp", "rlang"],
       "Hash": "501744395cac0bab0fbcfab9375ae92c"
     },
     "lattice": {
@@ -1891,14 +1601,7 @@
       "Version": "0.22-6",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "grid",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "grDevices", "graphics", "grid", "stats", "utils"],
       "Hash": "cc5ac1ba4c238c7ca9fa6a87ca11a7e2"
     },
     "lazyeval": {
@@ -1906,9 +1609,7 @@
       "Version": "0.2.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
     },
     "lifecycle": {
@@ -1916,12 +1617,7 @@
       "Version": "1.0.4",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "cli",
-        "glue",
-        "rlang"
-      ],
+      "Requirements": ["R", "cli", "glue", "rlang"],
       "Hash": "b8552d117e1b808b09a832f589b79035"
     },
     "limma": {
@@ -1971,10 +1667,7 @@
       "Version": "1.5-9.10",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "lattice"
-      ],
+      "Requirements": ["R", "lattice"],
       "Hash": "7d8e0ac914051ca0254332387d9b5816"
     },
     "logger": {
@@ -1982,10 +1675,7 @@
       "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "f25d781d5bc7757e08cf38c741a5ad1c"
     },
     "lubridate": {
@@ -1993,12 +1683,7 @@
       "Version": "1.9.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "generics",
-        "methods",
-        "timechange"
-      ],
+      "Requirements": ["R", "generics", "methods", "timechange"],
       "Hash": "be38bc740fc51783a78edb5a157e4104"
     },
     "magrittr": {
@@ -2006,9 +1691,7 @@
       "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "7ce2733a9826b3aeb1775d56fd305472"
     },
     "matrixStats": {
@@ -2016,9 +1699,7 @@
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "9fd316b52ac8c24fef4c67fdd646e965"
     },
     "memoise": {
@@ -2026,10 +1707,7 @@
       "Version": "2.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "cachem",
-        "rlang"
-      ],
+      "Requirements": ["cachem", "rlang"],
       "Hash": "e2817ccf4a065c5d9d7f2cfbe7c1d78c"
     },
     "mgcv": {
@@ -2054,11 +1732,7 @@
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "stats"
-      ],
+      "Requirements": ["R", "graphics", "stats"],
       "Hash": "f9d226d88d4087d817d4e616626ce8e5"
     },
     "mime": {
@@ -2066,9 +1740,7 @@
       "Version": "0.12",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "tools"
-      ],
+      "Requirements": ["tools"],
       "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
     },
     "minqa": {
@@ -2076,9 +1748,7 @@
       "Version": "1.2.8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "Rcpp"
-      ],
+      "Requirements": ["Rcpp"],
       "Hash": "785ef8e22389d4a7634c6c944f2dc07d"
     },
     "modelr": {
@@ -2104,10 +1774,7 @@
       "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "colorspace",
-        "methods"
-      ],
+      "Requirements": ["colorspace", "methods"],
       "Hash": "4fd8900853b746af55b81fda99da7695"
     },
     "mvtnorm": {
@@ -2115,10 +1782,7 @@
       "Version": "1.3-3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats"
-      ],
+      "Requirements": ["R", "stats"],
       "Hash": "c7241e6be9d6df551a2e539a50f5c875"
     },
     "nestcolor": {
@@ -2131,12 +1795,7 @@
       "RemoteRepo": "nestcolor",
       "RemoteRef": "main",
       "RemoteSha": "f2a1559926431d8abd1ec32c6b30ae08b87b166b",
-      "Requirements": [
-        "R",
-        "checkmate",
-        "ggplot2",
-        "lifecycle"
-      ],
+      "Requirements": ["R", "checkmate", "ggplot2", "lifecycle"],
       "Hash": "0498a54eaab9378e01a8bf34979375bd"
     },
     "nlme": {
@@ -2144,13 +1803,7 @@
       "Version": "3.1-166",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "graphics",
-        "lattice",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "graphics", "lattice", "stats", "utils"],
       "Hash": "ccbb8846be320b627e6aa2b4616a2ded"
     },
     "nloptr": {
@@ -2165,11 +1818,7 @@
       "Version": "7.3-20",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "stats", "utils"],
       "Hash": "c955edf99ff24a32e96bd0a22645af60"
     },
     "nortest": {
@@ -2177,9 +1826,7 @@
       "Version": "1.0-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "stats"
-      ],
+      "Requirements": ["stats"],
       "Hash": "e587e7a30c737ad415590976481332e4"
     },
     "numDeriv": {
@@ -2187,9 +1834,7 @@
       "Version": "2016.8-1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "df58958f293b166e4ab885ebcad90e02"
     },
     "officer": {
@@ -2217,9 +1862,7 @@
       "Version": "2.3.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "askpass"
-      ],
+      "Requirements": ["askpass"],
       "Hash": "37a7f0abce0349f5950ce49f38c7626b"
     },
     "pbkrtest": {
@@ -2261,9 +1904,7 @@
       "Version": "2.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
+      "Requirements": ["utils"],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
     "plogr": {
@@ -2310,10 +1951,7 @@
       "Version": "1.8.9",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "Rcpp"
-      ],
+      "Requirements": ["R", "Rcpp"],
       "Hash": "6b8177fd19982f0020743fadbfdbd933"
     },
     "png": {
@@ -2321,9 +1959,7 @@
       "Version": "0.1-8",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "bd54ba8a0a5faded999a7aab6e46b374"
     },
     "prettyunits": {
@@ -2331,9 +1967,7 @@
       "Version": "1.2.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "6b01fc98b1e86c4f705ce9dcfd2f57c7"
     },
     "productplots": {
@@ -2341,10 +1975,7 @@
       "Version": "0.1.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "ggplot2",
-        "plyr"
-      ],
+      "Requirements": ["ggplot2", "plyr"],
       "Hash": "75630cc31052ba299a52bb1adbf59fae"
     },
     "progress": {
@@ -2352,13 +1983,7 @@
       "Version": "1.2.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "R6",
-        "crayon",
-        "hms",
-        "prettyunits"
-      ],
+      "Requirements": ["R", "R6", "crayon", "hms", "prettyunits"],
       "Hash": "f4625e061cb2865f111b47ff163a5ca6"
     },
     "promises": {
@@ -2382,14 +2007,7 @@
       "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cli",
-        "lifecycle",
-        "magrittr",
-        "rlang",
-        "vctrs"
-      ],
+      "Requirements": ["R", "cli", "lifecycle", "magrittr", "rlang", "vctrs"],
       "Hash": "1cba04a4e9414bdefc9dcaa99649a8dc"
     },
     "quantreg": {
@@ -2415,10 +2033,7 @@
       "Version": "1.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "systemfonts",
-        "textshaping"
-      ],
+      "Requirements": ["systemfonts", "textshaping"],
       "Hash": "0595fe5e47357111f29ad19101c7d271"
     },
     "random.cdisc.data": {
@@ -2446,9 +2061,7 @@
       "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
     },
     "rbibutils": {
@@ -2456,11 +2069,7 @@
       "Version": "2.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "tools",
-        "utils"
-      ],
+      "Requirements": ["R", "tools", "utils"],
       "Hash": "dfc034a172fd88fc66b1a703894c4185"
     },
     "reformulas": {
@@ -2468,12 +2077,7 @@
       "Version": "0.4.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "Matrix",
-        "Rdpack",
-        "methods",
-        "stats"
-      ],
+      "Requirements": ["Matrix", "Rdpack", "methods", "stats"],
       "Hash": "d23beb08dca526d22ff47ce399260ba4"
     },
     "renv": {
@@ -2481,9 +2085,7 @@
       "Version": "1.0.11",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "utils"
-      ],
+      "Requirements": ["utils"],
       "Hash": "47623f66b4e80b3b0587bc5d7b309888"
     },
     "rjson": {
@@ -2491,9 +2093,7 @@
       "Version": "0.2.23",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "7a04e9eff95857dbf557b4e5f0b3d1a8"
     },
     "rlang": {
@@ -2501,10 +2101,7 @@
       "Version": "1.1.5",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "724dcc1490cd7071ee75ca2994a5446e"
     },
     "rmarkdown": {
@@ -2535,9 +2132,7 @@
       "Version": "2.0.4",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "4c8415e0ec1e29f3f4f6fc108bef0144"
     },
     "rtables": {
@@ -2563,13 +2158,7 @@
       "Version": "0.4.9",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R6",
-        "fs",
-        "htmltools",
-        "rappdirs",
-        "rlang"
-      ],
+      "Requirements": ["R6", "fs", "htmltools", "rappdirs", "rlang"],
       "Hash": "d53dbfddf695303ea4ad66f86e99b95d"
     },
     "scales": {
@@ -2597,12 +2186,7 @@
       "Version": "1.4.6.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics",
-        "stats"
-      ],
+      "Requirements": ["R", "grDevices", "graphics", "stats"],
       "Hash": "5c47e84dc0a3ca761ae1d307889e796d"
     },
     "shiny": {
@@ -2643,10 +2227,7 @@
       "Version": "0.2.1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "shiny"
-      ],
+      "Requirements": ["R", "shiny"],
       "Hash": "5e9a50d226ea7bf8d93d583a93b39b36"
     },
     "shinyTree": {
@@ -2687,12 +2268,7 @@
       "Version": "0.3.3",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "htmltools",
-        "htmlwidgets",
-        "jsonlite",
-        "shiny"
-      ],
+      "Requirements": ["htmltools", "htmlwidgets", "jsonlite", "shiny"],
       "Hash": "7dc8feb4207741ff581422a04fc8f3ea"
     },
     "shinycssloaders": {
@@ -2715,12 +2291,7 @@
       "Version": "2.1.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "digest",
-        "jsonlite",
-        "shiny"
-      ],
+      "Requirements": ["R", "digest", "jsonlite", "shiny"],
       "Hash": "802e4786b353a4bb27116957558548d5"
     },
     "shinyvalidate": {
@@ -2728,12 +2299,7 @@
       "Version": "0.1.3",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "glue",
-        "htmltools",
-        "rlang",
-        "shiny"
-      ],
+      "Requirements": ["glue", "htmltools", "rlang", "shiny"],
       "Hash": "fe6e75a1c1722b2d23cb4d4dbe1006df"
     },
     "snow": {
@@ -2741,10 +2307,7 @@
       "Version": "0.4-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "utils"
-      ],
+      "Requirements": ["R", "utils"],
       "Hash": "40b74690debd20c57d93d8c246b305d4"
     },
     "sourcetools": {
@@ -2752,9 +2315,7 @@
       "Version": "0.1.7-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "5f5a7629f956619d519205ec475fe647"
     },
     "statmod": {
@@ -2762,11 +2323,7 @@
       "Version": "1.5.0",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "graphics",
-        "stats"
-      ],
+      "Requirements": ["R", "graphics", "stats"],
       "Hash": "26e158d12052c279bdd4ba858b80fb1f"
     },
     "stringi": {
@@ -2774,12 +2331,7 @@
       "Version": "1.8.4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats",
-        "tools",
-        "utils"
-      ],
+      "Requirements": ["R", "stats", "tools", "utils"],
       "Hash": "39e1144fd75428983dc3f63aa53dfa91"
     },
     "stringr": {
@@ -3230,10 +2782,7 @@
       "Version": "0.3.0",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "cpp11"
-      ],
+      "Requirements": ["R", "cpp11"],
       "Hash": "c5f3c201b931cd6474d17d8700ccb1c8"
     },
     "tinytex": {
@@ -3241,9 +2790,7 @@
       "Version": "0.54",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "xfun"
-      ],
+      "Requirements": ["xfun"],
       "Hash": "3ec7e3ddcacc2d34a9046941222bf94d"
     },
     "utf8": {
@@ -3251,9 +2798,7 @@
       "Version": "1.2.4",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "62b65c52671e6665f803ff02954446e9"
     },
     "uuid": {
@@ -3261,9 +2806,7 @@
       "Version": "1.2-1",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "34e965e62a41fcafb1ca60e9b142085b"
     },
     "vctrs": {
@@ -3271,13 +2814,7 @@
       "Version": "0.6.5",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "cli",
-        "glue",
-        "lifecycle",
-        "rlang"
-      ],
+      "Requirements": ["R", "cli", "glue", "lifecycle", "rlang"],
       "Hash": "c03fa420630029418f7e6da3667aac4a"
     },
     "viridisLite": {
@@ -3285,9 +2822,7 @@
       "Version": "0.4.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R"
-      ],
+      "Requirements": ["R"],
       "Hash": "c826c7c4241b6fc89ff55aaea3fa7491"
     },
     "withr": {
@@ -3295,11 +2830,7 @@
       "Version": "3.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "graphics"
-      ],
+      "Requirements": ["R", "grDevices", "graphics"],
       "Hash": "cc2d62c76458d425210d1eb1478b30b4"
     },
     "xfun": {
@@ -3307,12 +2838,7 @@
       "Version": "0.50",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "grDevices",
-        "stats",
-        "tools"
-      ],
+      "Requirements": ["R", "grDevices", "stats", "tools"],
       "Hash": "44ab88837d3f8dfc66a837299b887fa6"
     },
     "xml2": {
@@ -3320,12 +2846,7 @@
       "Version": "1.3.6",
       "Source": "Repository",
       "Repository": "RSPM",
-      "Requirements": [
-        "R",
-        "cli",
-        "methods",
-        "rlang"
-      ],
+      "Requirements": ["R", "cli", "methods", "rlang"],
       "Hash": "1d0336142f4cd25d8d23cd3ba7a8fb61"
     },
     "xtable": {
@@ -3333,11 +2854,7 @@
       "Version": "1.8-4",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "stats",
-        "utils"
-      ],
+      "Requirements": ["R", "stats", "utils"],
       "Hash": "b8acdf8af494d9ec19ccb2481a9b11c2"
     },
     "yaml": {
@@ -3356,10 +2873,10 @@
     },
     "zlibbioc": {
       "Package": "zlibbioc",
-      "Version": "1.48.2",
+      "Version": "1.50.0",
       "Source": "Bioconductor",
       "Repository": "Bioconductor 3.19",
-      "Hash": "2344be62c2da4d9e9942b5d8db346e59"
+      "Hash": "3db02e3c460e1c852365df117a2b441b"
     }
   }
 }


### PR DESCRIPTION
Uses the BioC package versions compatible with R version `4.1.1` which fixes the stable deployment of RNA-seq app.