### PR TITLE
Deploy apps without skipping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,7 +157,6 @@ jobs:
 
       - name: Install R packages using renv and update the renv snapshot
         shell: Rscript {0}
-        if: steps.skip_check.outputs.skip == 'false'
         working-directory: ${{ matrix.directory }}
         run: |
           options(renv.config.cache.symlinks = FALSE)
@@ -172,7 +171,7 @@ jobs:
         run: cat renv.lock
 
       - name: Front end test to check if the app works fine
-        if: steps.find-cypress.outputs.has-cypress-tests == 'true' && steps.skip_check.outputs.skip == 'false'
+        if: steps.find-cypress.outputs.has-cypress-tests == 'true'
         uses: cypress-io/github-action@v6
         with:
           build: npm install cypress --save-dev
@@ -183,14 +182,12 @@ jobs:
 
       - name: Install deployment-related R package dependencies
         shell: Rscript {0}
-        if: steps.skip_check.outputs.skip == 'false'
         working-directory: ${{ matrix.directory }}
         run: |
           install.packages(c("BiocManager", "rsconnect"))
 
       - name: Deploy 🖨 ${{ matrix.directory }} 🎨
         shell: Rscript {0}
-        if: steps.skip_check.outputs.skip == 'false'
         working-directory: ${{ matrix.directory }}
         run: |
           rsconnect::setAccountInfo(
@@ -211,7 +208,6 @@ jobs:
           )
 
       - name: Commit and push changes 📌
-        if: steps.skip_check.outputs.skip == 'false'
         run: |
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions"


### PR DESCRIPTION
It looks like the apps are [not currently updated during deployment](https://github.com/insightsengineering/teal.gallery/actions/runs/13869004070/job/38813170293). This PR removes the skip condition that was skipping certain steps.