### PR TITLE
fix: change repo

### DIFF
--- a/RNA-seq/renv.lock
+++ b/RNA-seq/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       }
     ]
   },

--- a/early-dev/renv.lock
+++ b/early-dev/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "BioC.BioCsoft",

--- a/efficacy/renv.lock
+++ b/efficacy/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "RSPM",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "CRAN",

--- a/exploratory/renv.lock
+++ b/exploratory/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "RSPM",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "CRAN",

--- a/longitudinal/renv.lock
+++ b/longitudinal/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "BioC.BioCsoft",

--- a/patient-profile/renv.lock
+++ b/patient-profile/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "BioC.BioCsoft",

--- a/python/renv.lock
+++ b/python/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "BioC.BioCsoft",

--- a/safety/renv.lock
+++ b/safety/renv.lock
@@ -24,7 +24,7 @@
       },
       {
         "Name": "CRAN",
-        "URL": "https://packagemanager.posit.co/cran/latest"
+        "URL": "https://cloud.r-project.org"
       },
       {
         "Name": "BioC.BioCsoft",


### PR DESCRIPTION
For some reason the `Rcpp` package is not being successfully built in the CI so installing it from binary source by changing the repo.