### PR TITLE
use rinpharma account for dev branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ on:
     - cron: "12 3 * * *"
 
 env:
-  SHINYAPPSIO_ACCOUNT: genentech
+  SHINYAPPSIO_ACCOUNT: rinpharma
   APP_PREFIX: NEST
   GITHUB_PAT: ${{ secrets.REPO_GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ The Stable version of the apps use the latest released packages while the dev ve
 
 | Stable version                                                                 | Dev version                                                                   |
 | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------- |
-| [basic-teal](https://genentech.shinyapps.io/NEST_basic-teal_stable/)           | [basic-teal](https://genentech.shinyapps.io/NEST_basic-teal_dev/)             |
-| [delayed-data](https://genentech.shinyapps.io/NEST_delayed-data)               | [delayed-data](https://genentech.shinyapps.io/NEST_delayed-data_dev/)         |
-| [custom-transform](https://genentech.shinyapps.io/NEST_custom-transform)       | [custom-transform](https://genentech.shinyapps.io/NEST_custom-transform_dev/) |
-| [exploratory](https://genentech.shinyapps.io/NEST_exploratory_stable/)         | [exploratory](https://genentech.shinyapps.io/NEST_exploratory_dev/)           |
-| [safety](https://genentech.shinyapps.io/NEST_safety_stable/)                   | [safety](https://genentech.shinyapps.io/NEST_safety_dev/)                     |
-| [efficacy](https://genentech.shinyapps.io/NEST_efficacy_stable/)               | [efficacy](https://genentech.shinyapps.io/NEST_efficacy_dev/)                 |
-| [patient-profile](https://genentech.shinyapps.io/NEST_patient-profile_stable/) | [patient-profile](https://genentech.shinyapps.io/NEST_patient-profile_dev/)   |
-| [early-dev](https://genentech.shinyapps.io/NEST_early-dev_stable/)             | [early-dev](https://genentech.shinyapps.io/NEST_early-dev_dev/)               |
-| [longitudinal](https://genentech.shinyapps.io/NEST_longitudinal_stable/)       | [longitudinal](https://genentech.shinyapps.io/NEST_longitudinal_dev/)         |
-| [RNA-seq](https://genentech.shinyapps.io/NEST_RNA-seq_stable/)                 | [RNA-seq](https://genentech.shinyapps.io/NEST_RNA-seq_dev/)                   |
-| [python](https://genentech.shinyapps.io/NEST_python_stable/)                   | [python](https://genentech.shinyapps.io/NEST_python_dev/)                     |
+| [basic-teal](https://rinpharma.shinyapps.io/NEST_basic-teal_stable/)           | [basic-teal](https://rinpharma.shinyapps.io/NEST_basic-teal_dev/)             |
+| [delayed-data](https://rinpharma.shinyapps.io/NEST_delayed-data)               | [delayed-data](https://rinpharma.shinyapps.io/NEST_delayed-data_dev/)         |
+| [custom-transform](https://rinpharma.shinyapps.io/NEST_custom-transform)       | [custom-transform](https://rinpharma.shinyapps.io/NEST_custom-transform_dev/) |
+| [exploratory](https://rinpharma.shinyapps.io/NEST_exploratory_stable/)         | [exploratory](https://rinpharma.shinyapps.io/NEST_exploratory_dev/)           |
+| [safety](https://rinpharma.shinyapps.io/NEST_safety_stable/)                   | [safety](https://rinpharma.shinyapps.io/NEST_safety_dev/)                     |
+| [efficacy](https://rinpharma.shinyapps.io/NEST_efficacy_stable/)               | [efficacy](https://rinpharma.shinyapps.io/NEST_efficacy_dev/)                 |
+| [patient-profile](https://rinpharma.shinyapps.io/NEST_patient-profile_stable/) | [patient-profile](https://rinpharma.shinyapps.io/NEST_patient-profile_dev/)   |
+| [early-dev](https://rinpharma.shinyapps.io/NEST_early-dev_stable/)             | [early-dev](https://rinpharma.shinyapps.io/NEST_early-dev_dev/)               |
+| [longitudinal](https://rinpharma.shinyapps.io/NEST_longitudinal_stable/)       | [longitudinal](https://rinpharma.shinyapps.io/NEST_longitudinal_dev/)         |
+| [RNA-seq](https://rinpharma.shinyapps.io/NEST_RNA-seq_stable/)                 | [RNA-seq](https://rinpharma.shinyapps.io/NEST_RNA-seq_dev/)                   |
+| [python](https://rinpharma.shinyapps.io/NEST_python_stable/)                   | [python](https://rinpharma.shinyapps.io/NEST_python_dev/)                     |
 
 ## Running the apps
 

--- a/RNA-seq/README.md
+++ b/RNA-seq/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_RNA-seq_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_RNA-seq_stable>
 
 ### Preview the app
 

--- a/_internal/quarto/demo-apps.yml
+++ b/_internal/quarto/demo-apps.yml
@@ -1,5 +1,5 @@
 - category: Teal Gallery Demo
-  deployment_server: https://genentech.shinyapps.io/
+  deployment_server: https://rinpharma.shinyapps.io/
   apps:
     - title: basic-teal
     - title: teal-as-shiny-module

--- a/_internal/utils/app_readme_template.Rmd
+++ b/_internal/utils/app_readme_template.Rmd
@@ -23,7 +23,7 @@ restore_and_run("`r params$app_name`", package_repo = "https://insightsengineeri
 ### View the deployed app
 
 ```{r, echo=FALSE, results='asis'}
-x <- cat(paste0("Deployed app: https://genentech.shinyapps.io/NEST_", params$app_name, "_stable"))
+x <- cat(paste0("Deployed app: https://rinpharma.shinyapps.io/NEST_", params$app_name, "_stable"))
 ```
 
 ### Preview the app

--- a/basic-teal/README.md
+++ b/basic-teal/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_basic-teal_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_basic-teal_stable>
 
 ### Preview the app
 

--- a/custom-transform/README.md
+++ b/custom-transform/README.md
@@ -13,7 +13,7 @@
 ### View the deployed app
 
 Deployed app:
-<https://genentech.shinyapps.io/NEST_custom-transform_stable>
+<https://rinpharma.shinyapps.io/NEST_custom-transform_stable>
 
 ### Preview the app
 

--- a/delayed-data/README.md
+++ b/delayed-data/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_delayed-data_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_delayed-data_stable>
 
 ### Preview the app
 

--- a/early-dev/README.md
+++ b/early-dev/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_early-dev_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_early-dev_stable>
 
 ### Preview the app
 

--- a/efficacy/README.md
+++ b/efficacy/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_efficacy_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_efficacy_stable>
 
 ### Preview the app
 

--- a/exploratory/README.md
+++ b/exploratory/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_exploratory_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_exploratory_stable>
 
 ### Preview the app
 

--- a/longitudinal/README.md
+++ b/longitudinal/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_longitudinal_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_longitudinal_stable>
 
 ### Preview the app
 

--- a/patient-profile/README.md
+++ b/patient-profile/README.md
@@ -13,7 +13,7 @@
 ### View the deployed app
 
 Deployed app:
-<https://genentech.shinyapps.io/NEST_patient-profile_stable>
+<https://rinpharma.shinyapps.io/NEST_patient-profile_stable>
 
 ### Preview the app
 

--- a/python/README.md
+++ b/python/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_python_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_python_stable>
 
 ### Preview the app
 

--- a/safety/README.md
+++ b/safety/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_safety_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_safety_stable>
 
 ### Preview the app
 

--- a/teal-as-shiny-module/README.md
+++ b/teal-as-shiny-module/README.md
@@ -12,7 +12,7 @@
 
 ### View the deployed app
 
-Deployed app: <https://genentech.shinyapps.io/NEST_basic-teal_stable>
+Deployed app: <https://rinpharma.shinyapps.io/NEST_basic-teal_stable>
 
 ### Preview the app
 


### PR DESCRIPTION
Close #236 

We're moving our teal.gallery example apps to `rinpharma` account. Update was done to `main` in #235, so now we need to do the same with `dev` branch to support our _dev example apps.

* Update all `genentech.shinyapps.io` to `rinpharma.shinyapps.io`